### PR TITLE
Add bs4 metapackage 

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -82,4 +82,4 @@ jobs:
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-    condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+    condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -112,4 +112,4 @@ jobs:
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)
-      condition: not(eq(variables['UPLOAD_PACKAGES'], 'False'))
+      condition: and(succeeded(), not(eq(variables['UPLOAD_PACKAGES'], 'False')))

--- a/.ci_support/linux_aarch64_python3.6.yaml
+++ b/.ci_support/linux_aarch64_python3.6.yaml
@@ -5,7 +5,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge,c4aarch64,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_aarch64_python3.7.yaml
+++ b/.ci_support/linux_aarch64_python3.7.yaml
@@ -5,7 +5,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge,c4aarch64,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/.ci_support/linux_aarch64_python3.8.yaml
+++ b/.ci_support/linux_aarch64_python3.8.yaml
@@ -5,7 +5,7 @@ cdt_arch:
 cdt_name:
 - cos7
 channel_sources:
-- conda-forge,c4aarch64,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
 docker_image:

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Current release info
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-beautifulsoup4-green.svg)](https://anaconda.org/conda-forge/beautifulsoup4) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/beautifulsoup4.svg)](https://anaconda.org/conda-forge/beautifulsoup4) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/beautifulsoup4.svg)](https://anaconda.org/conda-forge/beautifulsoup4) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/beautifulsoup4.svg)](https://anaconda.org/conda-forge/beautifulsoup4) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-bs4-green.svg)](https://anaconda.org/conda-forge/bs4) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/bs4.svg)](https://anaconda.org/conda-forge/bs4) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/bs4.svg)](https://anaconda.org/conda-forge/bs4) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/bs4.svg)](https://anaconda.org/conda-forge/bs4) |
 
 Installing beautifulsoup4
 =========================
@@ -180,10 +181,10 @@ Installing `beautifulsoup4` from the `conda-forge` channel can be achieved by ad
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `beautifulsoup4` can be installed with:
+Once the `conda-forge` channel has been enabled, `beautifulsoup4, bs4` can be installed with:
 
 ```
-conda install beautifulsoup4
+conda install beautifulsoup4 bs4
 ```
 
 It is possible to list all of the versions of `beautifulsoup4` available on your platform with:

--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,0 +1,4 @@
+:: only really needed for win and py27,
+:: we can drop this line when we drop py27
+del /f /q NEWS.txt
+%PYTHON% -m pip install . --no-deps -vv

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,1 @@
+$PYTHON -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,21 +11,31 @@ source:
 build:
   # Uses 2to3 and cannot be noarch.
   number: 0
-  script:
-    - del /f /q NEWS.txt  # [win and py27]
-    - "{{ PYTHON }} -m pip install . --no-deps -vv"
 
-requirements:
-  host:
-    - python
-    - pip
-  run:
-    - python
-    - soupsieve >=1.2
+outputs:
+  - name: beautifulsoup4
+    script: build_base.bat  # [win]
+    script: build_base.sh  # [not win]
+    requirements:
+      host:
+        - python
+        - pip
+      run:
+        - python
+        - soupsieve >=1.2
+    test:
+      imports:
+        - bs4
 
-test:
-  imports:
-    - bs4
+  - name: bs4
+    build:
+      noarch: generic
+    requirements:
+      run:
+        - {{ pin_subpackage('beautifulsoup4', max_pin="x.x.x") }}
+    test:
+      imports:
+        - bs4
 
 about:
   home: http://www.crummy.com/software/BeautifulSoup/


### PR DESCRIPTION
PyPI has a metapackage for this and so should we. Also, this will help with some `pip check` commands that expect `bs4` instead of `beautifulsoup4`.